### PR TITLE
main

### DIFF
--- a/docs/arch_exp/turpan/connexion/index.md
+++ b/docs/arch_exp/turpan/connexion/index.md
@@ -105,6 +105,8 @@ Visual Studio Code doit être installé sur votre machine locale. Après avoir t
 code --remote ssh-remote+turpanlogin /path/on/turpan/mon_projet
 ```
 
+Vous pouvez également ouvrir VS Code et accéder facilement à toutes les machines auxquelles vous vous êtes connecté ainsi qu'à tous vos projets, avec le même environnement sauvegardé. Pour cela, utilisez l'onglet Remote Explorer situé à droite ([Tutoriel pour en savoir plus](https://code.visualstudio.com/docs/remote/ssh)).
+
 ## Se connecter aux équipements graphiques
 
 Vous pouvez visualiser vos données ou résultats de calculs sans devoir les déplacer de la machine Turpan à l'aide de [cette documentation](./visu.md).

--- a/docs/arch_exp/turpan/jobs.md
+++ b/docs/arch_exp/turpan/jobs.md
@@ -72,7 +72,7 @@ Exemple script shared, 1 nœud, 40 processeurs,  le temps d'exécution moins de 
 </Tabs>
 
 :::caution
-Sur Turpan, il est nécessaire d'utiliser **mpirun** et d'éviter srun, sauf si un conteneur est utilisé ([voir ici](./logiciels/apptainer.md)).
+Sur Turpan, si l'application utilise **MPI**, il est nécessaire d'utiliser **mpirun** et d'éviter srun, sauf si un conteneur est utilisé ([voir ici](./logiciels/apptainer.md)). Pour les autres applications, srun reste valide
 :::
 
 ## Obtenir des informations sur un job

--- a/docs/arch_exp/turpan/performance/map.md
+++ b/docs/arch_exp/turpan/performance/map.md
@@ -23,9 +23,11 @@ map --profile mpirun mon_appli...
 ```
 
 ### Voir les résultats avec map
-La commande ci-dessus produira un fichier dont le nom ressemblera à : mon_appli.map
+La commande ci-dessus produira un fichier dont le nom ressemblera à : mon_appli.map.
 
-Pour visualiser ce fichier, Il suffit alors d'ouvrir le visualiseur par :
+Il est fortement recommandé d'ouvrir les résultats avec la commande indiquée ci-dessous en utilisant la visualisation à distance ([voir ici](../connexion/visu.md)).
+
+Une autre méthode, moins recommandée, consiste à visualiser ce fichier en ouvrant le visualiseur avec :
 - Vous connecter avec ssh -X (une session X11)
 - Si le débit réseau est insuffisant, ssh -XC permet d’améliorer la fluidité de l'affichage
 - Si cela ne suffit pas, utilisez une session graphique


### PR DESCRIPTION
- Définir la limite de processus pour MAP
- Amélioration de la documentation PyTorch Turpan. Nouveau fichier d’exemple .tgz ajouté.
- Vscode avec turpan
- Utiliser mpirun et éviter srun
- Visualisation des résultats de MAP
- Update la documentation de MAQAO
- MAQAO résultats
- Clarifier l'utilisation de mpirun vs srun
- Recommander la visualisation à distance
- Vs code Remote Explorer
