### PR TITLE
main

### DIFF
--- a/docs/arch_exp/turpan/accounting/accounting-rules.md
+++ b/docs/arch_exp/turpan/accounting/accounting-rules.md
@@ -22,18 +22,18 @@ Pour une réservation sur ces partitions, les nœuds sont attribués dans leur i
 
 :::info
 
-(nombre de **nœuds réservés**) * (**80 cœurs**) * (**temps** de réservation **effectivement utilisé**)
+(nombre de **nœuds réservés**) \* (**80 cœurs**) \* (**temps** de réservation **effectivement utilisé**)
 
 :::
 
   </TabItem>
-  <TabItem label="Partition share et visu" value="shared">
+  <TabItem label="Partition shared et visu" value="shared">
 
 Pour une réservation sur les partition shared ou visu, le nœud est partagé entre plusieurs utilisateurs. Tout nœud réservé est comptabilisé de la manière suivante :
 
 :::info
 
-(nombre de **cœurs réservés**) * (**temps** de réservation **effectivement utilisé**)
+(nombre de **cœurs réservés**) \* (**temps** de réservation **effectivement utilisé**)
 
 :::
 
@@ -51,60 +51,61 @@ Bien que leur consommation soit affichée, la consommation des cartes GPU n'est 
 <Tabs>
   <TabItem label="Partitions small big et full" value="notshared" default>
 
-* Je lance un job sur 2 nœuds, en lançant 80 tâches par nœud.
-* Mon job met 15h à tourner.
-* L’en-tête de mon script SLURM ressemblera à quelque chose comme :
-
->```
->#SBATCH -N 2
->#SBATCH -n 160
->#SBATCH -p small
->#SBATCH --ntasks-per-node=80
->#SBATCH --ntasks-per-core=1
->#SBATCH --time=20:00:00
->```
-
-Il me sera décompté (2 nœuds) * (80 cpus) * (15 h) = 2400 h_cpus Pour rappel : 80 cœurs de calculs par noeud de Turpan.
-
-  </TabItem>
-  <TabItem label="Partitions small big et full (dépleuplé)" value="notshared-sparse">
-
-* Je lance un job sur 2 nœuds en dépeuplé, en lançant 40 tâches par nœud.
-* Mon job met 15h à tourner.
-* L’en-tête de mon script SLURM ressemblera à quelque chose comme :
-
->```
->#SBATCH -N 2
->#SBATCH -n 160
->#SBATCH -p small
->#SBATCH --ntasks-per-node=40
->#SBATCH --ntasks-per-core=1
->#SBATCH --time=20:00:00
->```
-
-Il me sera décompté (2 nœuds) * (80 cpus) * (15 h) = 2400 h_cpus Pour rappel : 80 cœurs de calculs par noeud de Turpan.
-
-  </TabItem>
-  <TabItem label="Partitions shared et visu" value="shared">
-
-* Je lance un job utilisant 4 cpu
-* Mon job met 15h à tourner.
+* Je lance un job sur 1 nœuds, en lançant **80** tâches par nœud.
+* Mon job met 0.049h(2.9m) à tourner.
 * L’en-tête de mon script SLURM ressemblera à quelque chose comme :
 
 >```
 >#SBATCH -N 1
->#SBATCH -n 4
+>#SBATCH -n 80
+>#SBATCH -p small
+>#SBATCH --ntasks-per-node=80
+>#SBATCH --ntasks-per-core=1
+>#SBATCH --time=04:00:00
+>```
+
+Il me sera décompté (1 nœuds) \* (80 cpus) \* (0.049 h) = 3.92 h_cpus.   Pour rappel : 80 cœurs de calculs par noeud de Turpan.
+
+  </TabItem>
+  <TabItem label="Partitions small big et full (dépleuplé)" value="notshared-sparse">
+
+* Je lance un job sur 1 nœuds en dépeuplé, en lançant **40** tâches par nœud.
+* Mon job met 0.049h(2.9m) à tourner.
+* L’en-tête de mon script SLURM ressemblera à quelque chose comme :
+
+>```
+>#SBATCH -N 1
+>#SBATCH -n 40
+>#SBATCH -p small
+>#SBATCH --ntasks-per-node=40
+>#SBATCH --ntasks-per-core=1
+>#SBATCH --time=04:00:00
+>```
+
+Il me sera décompté (1 nœuds) \* (80 cpus) \* (0.049 h) = 3.92 h_cpus. Pour rappel : 80 cœurs de calculs par noeud de Turpan.
+**Le même nombre d'heures, même avec moins de tâches, car tout le nœud sera réservé, même s'il n'est pas utilisé entièrement.**
+
+  </TabItem>
+  <TabItem label="Partitions shared et visu" value="shared">
+
+* Je lance un job utilisant **40** tâches.
+* Mon job met 0.049h(2.9m) à tourner.
+* L’en-tête de mon script SLURM ressemblera à quelque chose comme :
+
+>```
+>#SBATCH -N 1
+>#SBATCH -n 40
 >#SBATCH -p shared
->#SBATCH --ntasks-per-node=4
+>#SBATCH --ntasks-per-node=40
 >#SBATCH --ntasks-per-core=1
 >#SBATCH --gres=gpu:1
 >#SBATCH --mem=20000
->#SBATCH --time=20:00:00
+>#SBATCH --time=04:00:00
 >```
 
-Il me sera décompté (4 cpus) * (15 h) = 60 h_cpus
-
-  </TabItem>
+Il me sera décompté (40 cpus) \* (0.049h) = 1.96 h_cpus.
+**Le nœud est partagé entre différents jobs, et seuls 40 cœurs sont réservé et utilisés (le nœud complet n'est pas réservé).**  
+</TabItem>
 </Tabs>
 
 ## Et si mon quota est épuisé ?

--- a/docs/arch_exp/turpan/jobs.md
+++ b/docs/arch_exp/turpan/jobs.md
@@ -8,13 +8,20 @@ import TabItem from '@theme/TabItem';
 
 # Comment lancer un calcul sur Turpan ? 
 
-Partition / global = 3 jobs max par utilisateur :
-
-- **small** : exclusive, 2 jobs max, pas plus de 6 noeuds par jobs, max walltime par job 4H
-- **big** : exclusive, 1 job max, pas plus de 13 noeuds par jobs, max walltime par job 2H
+<!-- Partition / global = 3 jobs max par utilisateur : -->
+L'utilisateur peut exécuter un maximum de 3 jobs simultanément, quelle que soit la partition utilisée. Dans tous les cas, il est impératif de respecter les contraintes spécifiques de chaque partition, comme indiqué ci-dessous :
+- **small** : exclusive, 2 jobs max, pas plus de 6 noeuds par jobs, max walltime par job 4H.
+- **big** : exclusive, 1 job max, pas plus de 13 noeuds par jobs, max walltime par job 2H.
 - **full** : exclusive, 1 job max, au moins 14 noeuds par jobs, max walltime par job 20H
-- **shared** : non exclusive, 2 jobs max, pas plus de 1 GPU, 40 cpu et 256G ram par jobs, max walltime par job 4H
-- **visu** : non exclusive, 1 job max, max 50Go RAM max 8 cpu par job, max walltime par job 4H
+- **visu** : non exclusive, 1 job max, max 50Go RAM max 8 cpu par job, max walltime par job 4H.
+- **shared** : non exclusive, 2 jobs max, max la moitié du noeud (40 cpu et 256G ram,1 GPU ), max walltime par job 4H.
+
+:::info
+* **Exclusive**: Un job en partition exclusive réserve l’intégralité des nœuds qui lui sont attribués.
+* **Non exclusive**: Un job en partition non exclusive ne réserve pas l’intégralité du nœud, ce qui permet à d’un autre job (d’un autre utilisateur) de partager les mêmes ressources.
+
+Le choix de la partition dépend des besoins en ressources, notamment en termes de nombre de cœurs par nœud et des limites de temps de calcul (walltime), veuillez consulter [les règles de comptabilisation des ressources ](./accounting/accounting-rules.md#exemples-).
+:::
 
 Afin de ne pas monopoliser l’ensemble des noeuds du cluster en journée :
 
@@ -72,7 +79,7 @@ Exemple script shared, 1 nœud, 40 processeurs,  le temps d'exécution moins de 
 </Tabs>
 
 :::caution
-Sur Turpan, si l'application utilise **MPI**, il est nécessaire d'utiliser **mpirun** et d'éviter srun, sauf si un conteneur est utilisé ([voir ici](./logiciels/apptainer.md)). Pour les autres applications, srun reste valide
+Sur Turpan, si l'application utilise **MPI**, il est nécessaire d'utiliser **mpirun** et d'éviter srun, sauf si un conteneur est utilisé ([voir ici](./logiciels/apptainer.md)). Pour les autres applications **sans MPI**, srun reste valide
 :::
 
 ## Obtenir des informations sur un job

--- a/docs/arch_exp/turpan/performance/nsight.md
+++ b/docs/arch_exp/turpan/performance/nsight.md
@@ -11,69 +11,53 @@ D'abord, il faut aller sur le nœud de calcul pour générer un rapport avec vot
 Ensuite, il faut aller sur le TurboVNC ouvrez une interface graphique nsys pour visualiser votre rapport.
 
 ## Exemple de rapport simple nœud
+La directive `#nvprofiling` est responsable de la configuration de l’environnement nécessaire pour NSIGHT.
 
 ```
 #!/usr/bin/bash
-#SBATCH -N 1
-#SBATCH -n 16
-#SBATCH --ntasks-per-node=16
+#SBATCH -N 1 
+#SBATCH -n 2 
+#SBATCH --ntasks-per-node=2
 #SBATCH --gres=gpu:2
-#SBATCH --time=01:00:00
-#SBATCH --mem=128G
-#SBATCH -p small
+#SBATCH --time=00:30:00
+#SBATCH -p small 
 #nvprofiling
 
 module purge
+module load nvidia 
+module load nvhpc/22.9
 module load amgx/nvidia/2.4.0-nvhpc231-system
-module load dcgm/3.1.3-1
+module load dcgm/system
 module list
 
-workdir=$PWD/${SLURM_JOBID}
+workdir=RUN/${SLURM_JOBID}
 mkdir ${workdir}
-
-cd ${workdir}
-\cp -f ../{bul3.*,jcl,PCG.json} .
-cp ../nsys.sh .
+cd ../${workdir}/
 cp $0 .
-maxit=4                                                                                                           
 
-export CUDA_VISIBLE_DEVICES=0,1
-export TEST_SYSTEM_PARAMS=1
-export UCX_MEMTYPE_CACHE=n
-
-export UCX_IB_GPU_DIRECT_RDMA=no
-echo "UCX_IB_GPU_DIRECT_RDMA=${UCX_IB_GPU_DIRECT_RDMA}"
-echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
-
-#DCGM
-nv-hostengine --pid nvhostengine.pid --log-filename nv-hostengine.log
-#PCIe
-dcgmi dmon -e 1009,1010 -c 200 > compteur.${SLURM_JOB_ID} &
-
-clush -w ${SLURM_NODELIST} nvidia-cuda-mps-control -d
-BIN=../my_application
-ldd ${BIN}
 nodeset -e ${SLURM_JOB_NODELIST} | tr ' ' '\n' > hostfile_${SLURM_JOBID}
-nsys profile -t mpi,ucx,openmp,openacc,oshmem,cuda,opengl,nvtx,osrt -o report-mpirun-singlenode mpirun -hostfile ./hostfile_${SLURM_JOBID} -np ${SLURM_NTASKS} --map-by ppr:${SLURM_NTASKS_PER_NODE}:socket:PE=1 $BIN 2 2 4
-clush -w ${SLURM_NODELIST}  echo quit | nvidia-cuda-mps-control
 
-kill -9 $(cat nvhostengine.pid)
+# Nsight profiling
+nsys profile \
+  -t mpi,ucx,openmp,openacc,oshmem,cuda,opengl,nvtx,osrt \
+  -o report-mpirun-singlenode \
+  mpirun -hostfile ./hostfile_${SLURM_JOBID} \
+         -np ${SLURM_NTASKS} \
+         --map-by ppr:${SLURM_NTASKS_PER_NODE}:socket:PE=2 \
+         ./mon_projet
 ```
 
 
 ## Visualisation de rapport simple nœud
-
+Connectez-vous sur Turpan par ssh [voir ici](../connexion/visu.md). Vous ouvrez un terminal sur le TurboVNC:
 ```
-#Vous ouvrez un terminal sur le TurboVNC :
-
 module load nvidia
 module load nvhpc/23.1
+
 cd /usr/local/arch-x86/nvidia/nvhpc/Linux_x86_64/23.1/profilers/Nsight_Systems/host-linux-x64/
+
 ./nsys-ui.vglrun.wrapper
-
-#Vous visualisez un rapport sur une interface graphique nsys :
-
-/tmpdir/jamal/Tests_Nsys/6147/report-mpirun-singlenode.nsys-rep
 ```
+Pour visualiser un rapport dans l'interface graphique de NSYS, utilisez la "open" dans Nsight pour ouvrir le fichier situé à : /tmpdir/username/mon_project/mon_project.nsys-rep.
 ![Capture d'écran du formulaire d'engistrement dans le SSO MesoNET](/img/turpan/nsight.png)
 


### PR DESCRIPTION
- Définir la limite de processus pour MAP
- Amélioration de la documentation PyTorch Turpan. Nouveau fichier d’exemple .tgz ajouté.
- Vscode avec turpan
- Utiliser mpirun et éviter srun
- Visualisation des résultats de MAP
- Update la documentation de MAQAO
- MAQAO résultats
- Clarifier l'utilisation de mpirun vs srun
- Recommander la visualisation à distance
- Vs code Remote Explorer
- Accounting exemple cohérent avec walltime limit
- Clarification des partitions exclusives et non exclusives, ainsi que de l'utilisation des ressources sur les partition.
- Utilisation de Nsight
