### PR TITLE
main

### DIFF
--- a/docs/arch_exp/turpan/logiciels/envpython/jupyterlab.md
+++ b/docs/arch_exp/turpan/logiciels/envpython/jupyterlab.md
@@ -108,6 +108,15 @@ Ceux-ci peuvent être utilisés en invoquant `runJupyterSession.sh` avec l'optio
 ```bash
 runJupyterSession.sh --container pytorch
 ```
+Il est possible de choisir la version du conteneur à l’aide de l’option `--flavor` :
+```bash
+runJupyterSession.sh --container pytorch --flavor 24.10
+```
+Pour consulter les versions disponibles, utilisez la commande suivante :
+```bash
+runJupyterSession.sh --container pytorch --help
+```
+
 ### Installer un paquet python supplémentaire dans mon environnement
 
 À l'intérieur d'une cellule du notebook, exécuter la commande `!pip install --user monpaquet'`


### PR DESCRIPTION
- Définir la limite de processus pour MAP
- Amélioration de la documentation PyTorch Turpan. Nouveau fichier d’exemple .tgz ajouté.
- Vscode avec turpan
- Utiliser mpirun et éviter srun
- Visualisation des résultats de MAP
- Update la documentation de MAQAO
- MAQAO résultats
- Clarifier l'utilisation de mpirun vs srun
- Recommander la visualisation à distance
- Vs code Remote Explorer
- Accounting exemple cohérent avec walltime limit
- Clarification des partitions exclusives et non exclusives, ainsi que de l'utilisation des ressources sur les partition.
- Utilisation de Nsight
- Updates and corrections on juliet documentation
- Mise à jour de la partie de connexion pour les non-académiques sur Juliet.
- Version plus propre de la modification des infos de connexion à Juliet pour les non-académiques
- Mise à jour de la doc Juliet pour correspondre aux modifications de politique de la machine
- Ajout d'un fichier d'index à la documentation de Juliet
- Ajout d'un processus pour la réservation
- Adding a tutorial for handling reservations on Juliet
- Correction on Juliet
- Mise à jour de la documentation Juliet sur le support.
- Edition de la partie réservation de Juliet
- Modification de la documentation pour que la clé ne soit plus nommée
- add support adress
- username form
- ajout vesta
- Correction d'une erreur de lien dans la documentation
- Slurm overview
- Actualités Turpan
- Ajout de la doc vscode server à juliet
- Correction d'une faute de frappe dans vscode.md
- Modified default QoS
- Ajout de la FAQ
- Correct Pytorch port
- MAJ Actualités
- choisir la version du conteneur
